### PR TITLE
Correction in French language string

### DIFF
--- a/tex/latex/genealogytree/gtrlang.french.code.tex
+++ b/tex/latex/genealogytree/gtrlang.french.code.tex
@@ -25,7 +25,7 @@
     Born=n\'e,
     Bornoutofwedlock=n\'e hors mariage,
     Stillborn=mort-n\'e,
-    Diedonbirthday=d\'ec\'ed\'e le jour de son anniversaire,
+    Diedonbirthday=d\'ec\'ed\'e le jour de sa naissance,
     Baptized=baptis\'e,
     Engaged=fianc\'e,
     Married=mari\'e,


### PR DESCRIPTION
birthday=jour de naissance, pas jour d'anniversaire

On s'en fiche de savoir qu'une personne est morte le jour de son anniversaire. Par contre mourir le jour de sa naissance c'est presque comme être mort né, mais un peu différement ;-)