### PR TITLE
`\gtrifdateorplacedefined` macro

### DIFF
--- a/tex/latex/genealogytree/gtrcore.node.code.tex
+++ b/tex/latex/genealogytree/gtrcore.node.code.tex
@@ -605,7 +605,7 @@
 
 \def\gtrPrintEvent@prefixdateplace#1{%
   \gtrkv@event@pre\gtrPrintEventPrefix{#1}%
-  \gtrkv@event@sepdate\gtrPrintDate{#1}%
+  \gtrifdatedefined{#1}{\gtrkv@event@sepdate\gtrPrintDate{#1}}{}%
   \gtrifplacedefined{#1}{\gtrkv@event@sepplace\gtrPrintPlace{#1}}{}%
   \gtrkv@event@app%
 }
@@ -621,9 +621,8 @@
   \gtrkv@event@app%
 }
 
-
-%%%%%%%%%%%%%%%%%%%%%%
-% Age, Comment, Profession and Places %
+%%%%%%%%%%%%%%%%%%%%%%%%%
+% Check for definitions %
 
 \def\gtrifagedefined#1#2{%
   \ifdefvoid{\gtrDBage}{#2}{#1}%
@@ -640,6 +639,23 @@
 \def\gtrifplacedefined#1#2#3{%
   \ifcsvoid{gtrDB#1place}{#3}{#2}%
 }
+
+\def\gtrifdatedefined#1#2#3{%
+  \ifcsdef{gtrDB#1year}{#2}{%
+    \ifcsdef{gtrDB#1endyear}{#2}{#3}%
+  }%
+}
+
+\def\gtrifdateorplacedefined#1#2#3{%
+  \gtrifdatedefined{#1}{#2}{
+    \gtrifplacedefined{#1}{#2}{#3}
+  }
+}
+
+\let\gtrifeventdefined=\gtrifdateorplacedefined
+
+%%%%%%%%%%
+% Places %
 
 \def\gtrPrintPlace#1{%
   \gtrkv@place@pre\csuse{gtrDB#1place}\gtrkv@place@app%
@@ -742,13 +758,6 @@
   \def\dot{.}%
   \pgfkeysvalueof{/gtr/month short/\csuse{#1}}%
 }}
-
-\def\gtrifdatedefined#1#2#3{%
-  \ifcsdef{gtrDB#1year}{#2}{%
-    \ifcsdef{gtrDB#1endyear}{#2}{#3}%
-  }%
-}
-\let\gtrifeventdefined=\gtrifdatedefined
 
 \def\gtr@dateformat@factory#1#2{%
   \csdef{gtrPrintDateCore@#1}##1{#2}%


### PR DESCRIPTION
Evaluates to true if either date or place is defined. This allows `\gtrPrintEvent@prefixdateplace` to print events that contain only a place, but no date. Can for example be used if a person has no known birth date, but the address is of interest, in conjunction with a baptismal date+place; likewise for death place + burial date:

```
{
	female,
	name = {Anne Sophie \surn{Tofte}},
	birth = {}{Nørrevold},
	baptism = {1790-06-28}{Trinitatis kirke},
	death = {1871-05-31}{Rigensgade 8},
	burial = {1871-06-04}{Skt. Paul kirke},
}
```

Renders as (symbols approximated):

```
Anne Sophie Tofte
* i Nørrevold
~ 28. juni 1790 i Trinitatis kirke
† 31. maj 1871 i Rigensgade 8
[] 4. juni 1871 i Skt. Paul kirke
```